### PR TITLE
Linux support

### DIFF
--- a/steam.log
+++ b/steam.log
@@ -1,0 +1,1 @@
+FMT.exe\nMessage: Failed to create CoreCLR, HRESULT: 0x80004005\n\n"


### PR DESCRIPTION
Hi Paul,

It seems you have disabled issues/discussions, which I do understand.
If you don't want to have any contact, please just let me know. :)

I'm trying to run your tool and FIFA 23 under Linux.
The reason is that I'm running Linux as my main driver, but also thinking of buying a Steam Deck.
I got it almost working by passing by EA's anti-cheat using the solution [xAranaktu](https://github.com/xAranaktu), but I need your tool to get it fully working (at least I think so).

For some reason, I'm unable to open your tool: `FMT.exe\nMessage: Failed to create CoreCLR, HRESULT: 0x80004005\n\n"`.
Do you have any idea? I'm running your tool with Steam (flatpak) + Proton Experimental (wine wrapper).

With my limited knowledge this seems a permissions issue, but I don't know for sure.

Thanks!